### PR TITLE
esp32 framework type changed from arduino to esp-idf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+__pycache__
+.esphome/
+secrets.yaml

--- a/components/twc_gen2/rs485.cpp
+++ b/components/twc_gen2/rs485.cpp
@@ -3,7 +3,6 @@
 #include <cstdarg>
 #include <cassert>
 #include <sstream>
-#include <Arduino.h>
 
 #include "esphome/core/log.h"
 #include "esphome/core/component.h"
@@ -409,7 +408,8 @@ void RS485::sender_task(void *pvParameter) {
 
     // Give time for the answer to be received.
     // vTaskDelay(500 + random(50, 100) / portTICK_PERIOD_MS);
-    vTaskDelay(200 + random(50, 100) / portTICK_PERIOD_MS);
+    uint32_t r = 50 + (esp_random() % 51); // [50, 100]
+    vTaskDelay(200 + r / portTICK_PERIOD_MS);
 
     // Should we send a START or STOP charging command?
     if (c->allow_charging != c->allow_charging_last_send) {
@@ -418,7 +418,8 @@ void RS485::sender_task(void *pvParameter) {
         rs485->send_command(START_CHARGING, c->twcid);
       else
         rs485->send_command(STOP_CHARGING, c->twcid);
-      vTaskDelay(200 + random(50, 100) / portTICK_PERIOD_MS);
+      uint32_t r = 50 + (esp_random() % 51); // [50, 100]
+      vTaskDelay(200 + r / portTICK_PERIOD_MS);
     }
 
     switch (c->command_nr) {
@@ -442,7 +443,8 @@ void RS485::sender_task(void *pvParameter) {
         break;
     }
     // Allow time for answer to be received (or a presence packet send be a new TWC)
-    vTaskDelay(200 + random(50, 100) / portTICK_PERIOD_MS);
+    r = 50 + (esp_random() % 51); // [50, 100]
+    vTaskDelay(200 + r / portTICK_PERIOD_MS);
 
     // Next command
     c->command_nr = (c->command_nr + 1) % 5;

--- a/components/twc_gen2/rs485.h
+++ b/components/twc_gen2/rs485.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <functional>
 #include <map>
+#include "esp_random.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include "esphome/components/uart/uart_component.h"

--- a/components/twc_gen2/twc_gen2_controller.cpp
+++ b/components/twc_gen2/twc_gen2_controller.cpp
@@ -1,6 +1,9 @@
 #include "twc_gen2_controller.h"
 #include <sstream>
 
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+
+
 namespace esphome {
 namespace twc_gen2 {
 
@@ -74,9 +77,9 @@ void TwcGen2Controller::loadbalance_max_current() {
   for (uint8_t n = 1; n <= 3; n++) {
     auto con = this->rs485_->get_connector_by_nr(n);
     if (con && (con->actual_current > 0)) {
-      con->max_current = min(this->twc_limit[n - 1], global_limit_divided_over_active_twcs);
+      con->max_current = MIN(this->twc_limit[n - 1], global_limit_divided_over_active_twcs);
     } else if (con) {
-      con->max_current = min(this->twc_limit[n - 1], this->global_limit);
+      con->max_current = MIN(this->twc_limit[n - 1], this->global_limit);
     }
   }
 }
@@ -106,7 +109,7 @@ void TwcGen2Controller::on_connector_changed(ConnectorState *c) {
     ESP_LOGI(TAG, "Initialized connector%d (serial: %s).", nr, s);
 
     // Set the limit of this TWC, initialize to the smallest limit.
-    c->max_current = min(this->twc_limit[nr - 1], this->global_limit);
+    c->max_current = MIN(this->twc_limit[nr - 1], this->global_limit);
   }
 
   // rs485_->log_connector_state(c);

--- a/components/twc_gen2/twc_gen2_controller.h
+++ b/components/twc_gen2/twc_gen2_controller.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <Arduino.h>
-
 #include "esphome/core/log.h"
 #include "esphome/core/component.h"
 #include "esphome/core/entity_base.h"

--- a/dev/esphome.sh
+++ b/dev/esphome.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# This script is used to run the ESPHome command in a container.
+# It is used to avoid having to install ESPHome on the host machine.
+# It is also used to avoid having to install the dependencies on the host machine.
+
+# Example to compile the TWC component: 
+# ./esphome.sh compile twctest.yaml
+
+# Fail fast: 
+# -e exit on error, 
+# -u error on unset vars, 
+# -o pipefail causes a pipeline to fail if any command fails (not just the last)
+set -euo pipefail
+
+# The ESPHome Docker image
+IMAGE="ghcr.io/esphome/esphome"
+
+# Use interactive TTY only when attached to a terminal
+TTY_ARGS=""
+if [ -t 0 ] && [ -t 1 ]; then
+  TTY_ARGS="-it"
+fi
+
+# Resolve repository root based on script location (this script lives in dev/)
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+# Run the ESPHome command in a container
+docker run --rm ${TTY_ARGS} \
+  -v "${REPO_ROOT}/dev:/config" \
+  -v "${REPO_ROOT}/components:/components" \
+  "${IMAGE}" "$@"

--- a/dev/twctest.yaml
+++ b/dev/twctest.yaml
@@ -1,25 +1,5 @@
-# twc_gen2
-Tesla Wall Connector (generation 2) ESPHome controller.
-
-Features:
-- control multiple Tesla Wall Connector's (TWC's)
-- load balancing between TWC's
-- configure maximum current for each individual TWC
-- configure maximum current for all TWC's combined
-- maximum current for all TWC's combined can be controller from Home Assistant
-- individual TWC's can be turned on/off from Home Assistant
-- sensors for current, voltage, VIN number, etc.
-
-
-This has been tested using an Olimex ESP32-POE-ISO-IND and an Olimex MOD-RS485.
-
-To find the serial number of your TWC, check the sticker located on the side of the device (the same side as the Reset button). The serial number is labeled as the “TSN” and consists of 11 alphanumeric characters, for example: A18B0001234.
-
-Example config file:
-```yaml
 esphome:
-  name: ...
-  friendly_name: ...
+  name: twctest
 
 esp32:
   board: esp32-poe-iso
@@ -35,22 +15,23 @@ logger:
 
 # Enable Home Assistant API
 api:
-  encryption:
-    key: ...
+  password: ""
 
 ota:
   - platform: esphome
-    password: ...
+    password: ""
 
-# Enable ethernet (for network and PoE)
-ethernet:
-  type: LAN8720
-  mdc_pin: GPIO23
-  mdio_pin: GPIO18
-  clk_mode: GPIO17_OUT
-  phy_addr: 0
-  power_pin: GPIO12
+wifi:
+  ssid: "testwifi"
+  password: ""
 
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "Twctest Fallback Hotspot"
+    password: "wvokFmWePmPC"
+
+captive_portal:
+    
 uart:
   id: twc_uart
   tx_pin: GPIO4
@@ -60,27 +41,24 @@ uart:
   parity: NONE
   stop_bits: 1
 
+
 external_components:
-  - source: github://erwin314/twc_gen2
+#  - source: github://erwin314/twc_gen2
+#    components: [twc_gen2]
+  - source:
+      type: local
+      path: /components
     components: [twc_gen2]
-  # Or you can use a local copy:
-  #- source:
-  #    type: local
-  #    path: /workspaces/esphome/esphome/components
-  #  components: [twc_gen2]
 
 twc_gen2:
   uart_id: twc_uart
   flow_control_pin: 14
   read_only: false
-  # Add the serial numbers of you Tesla Wall Connector's here.
-  # Set read_only to True if you don't know your serial number(s),
-  # you can than look in the logs to find the serial number(s).
-  c1_serial: A1.........
-  c2_serial: A1.........
+  c1_serial: A18G0005893
+  c2_serial: A18H0020359
   global_limit: 16
-  c1_limit: 16
-  c2_limit: 16
+  c1_limit: 32
+  c2_limit: 32
 
 number:
   - platform: twc_gen2
@@ -90,10 +68,12 @@ number:
       max_value: 32
 
 switch:
-  - platform: twc_gen2
+  - platform: twc_gen2    
     c1_allow_charging:
+      restore_mode: RESTORE_DEFAULT_OFF
       name: 1 Allow Charging
     c2_allow_charging:
+      restore_mode: RESTORE_DEFAULT_OFF
       name: 2 Allow Charging
 
 text_sensor:
@@ -149,4 +129,3 @@ sensor:
     name: 1 Actual Current
   c2_actual_current:
     name: 2 Actual Current
-```


### PR DESCRIPTION
Starting with ESPHome 2026.1.0, the default framework for ESP32 will change from Arduino to ESP-IDF (see the [ESP32 Arduino to ESP-IDF Migration Guide](https://esphome.io/guides/esp32_arduino_to_idf/) for more details).

When upgrading the TWC component the configuration yaml file should be changed. The esp32 framework type should be changed from arduino to esp-idf:

```
...
esp32:
  board: esp32-poe-iso
  framework:
    type: esp-idf        // <-- This was "arduino"
...
```
Upgrade tips:
- make sure to "Clean Build Files" 
- ESPHome should fetch the latest source code from git (by default it only checks once per day), see [Refresh docs](https://esphome.io/components/external_components/#refresh)
